### PR TITLE
Feature/selectors

### DIFF
--- a/UniversalFriends-core/src/main/java/me/ironexception/universalfriends/association/Association.java
+++ b/UniversalFriends-core/src/main/java/me/ironexception/universalfriends/association/Association.java
@@ -44,21 +44,31 @@ public enum Association {
      * @return The association related to the friendliness value. <code>null</code> if there is no {@link Association} with the provided value.
      * @author 086
      */
-    public static Association byValue(double value) {
+    public static Association byExactValue(double value) {
         return Arrays.stream(values()).filter(association -> association.getValue() == value).findAny().orElseGet(null);
     }
 
     /**
-     * Fetch the {@link Association} closest to a friendliness value.
-     * <p>Edge cases: <code>0.5</code> becomes {@link Association#ALLY} and <code>-0.5</code> becomes {@link Association#ENEMY}</p>
+     * Fetch a {@link Association} by what the value means.
+     * <ul>
+     *     <li>
+     *         If the provided value is lower than the standardised neutral value, this method will return {@link Association#ENEMY}
+     *     </li>
+     *     <li>
+     *         If the provided value is higher than the standardised neutral value, this method will return {@link Association#ALLY}
+     *     </li>
+     *     <li>
+     *         If the provided value is equal to the standardised neutral value, this method will return {@link Association#NEUTRAL}
+     *     </li>
+     * </ul>
      * @param value The friendliness value
-     * @return      The {@link Association} with a friendliness value closest to the provided value
-     * @author 086
+     * @return      The {@link Association} with a friendliness value depending to the provided value
+     * @author IronException
      */
-    public static Association closestToValue(double value) {
-        if (value == Double.MIN_VALUE) return Association.ENEMY;
-        if (value == Double.MAX_VALUE) return Association.ALLY;
-        return Arrays.stream(values()).min(Comparator.comparingDouble(a -> Math.abs(a.value - value))).get();
+    public static Association byValue(final double value) {
+        if (value < Standard.STANDARD_NEUTRAL) return Association.ENEMY;
+        if (value > Standard.STANDARD_NEUTRAL) return Association.ALLY;
+        return Association.NEUTRAL;
     }
 
     public double getValue() {

--- a/UniversalFriends-core/src/main/java/me/ironexception/universalfriends/configuration/Operations.java
+++ b/UniversalFriends-core/src/main/java/me/ironexception/universalfriends/configuration/Operations.java
@@ -16,10 +16,6 @@ public class Operations {
         return filterMatchingPersons(configuration, t -> t.getValue() == value);
     }
 
-    public static <T extends IPerson> Set<T> getByCloseToAssociation(Configuration<T> configuration, Association association) {
-        return filterMatchingPersons(configuration, t -> Association.closestToValue(t.getValue()) == association);
-    }
-
     public static <T extends IPerson> Set<T> getByAssociation(Configuration<T> configuration, Association association) {
         double value = association.getValue();
         return getByFriendliness(configuration, value);

--- a/UniversalFriends-core/src/main/java/me/ironexception/universalfriends/select/Selector.java
+++ b/UniversalFriends-core/src/main/java/me/ironexception/universalfriends/select/Selector.java
@@ -1,0 +1,100 @@
+package me.ironexception.universalfriends.select;
+
+import me.ironexception.universalfriends.Standard;
+import me.ironexception.universalfriends.association.Association;
+import me.ironexception.universalfriends.configuration.Configuration;
+import me.ironexception.universalfriends.person.IPerson;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * A utility class to perform a selection on the friend list of a {@link Configuration}.
+ * @param <P>   The type of {@link IPerson} the {@link Configuration} holds
+ * @param <T>   The type of {@link Configuration} to select in
+ */
+public class Selector<P extends IPerson, T extends Configuration<P>> {
+
+    private final T configuration;
+    private final Set<Predicate<P>> predicates;
+
+    private Selector(T configuration) {
+        this.configuration = configuration;
+        this.predicates = new HashSet<>();
+    }
+
+    public static <P extends IPerson, T extends Configuration<P>> Selector<P, T> create(T configuration) {
+        return new Selector<>(configuration);
+    }
+
+    /**
+     * Select only {@link IPerson} instances with a value exclusively higher than {@link Standard#STANDARD_NEUTRAL}
+     * @return  The mutated {@link Selector}
+     */
+    public Selector<P, T> friends() {
+        predicates.add(p -> p.getValue() > Standard.STANDARD_NEUTRAL);
+        return this;
+    }
+
+    /**
+     * Select only {@link IPerson} instances with a value exclusively lower than {@link Standard#STANDARD_NEUTRAL}
+     * @return  The mutated {@link Selector}
+     */
+    public Selector<P, T> enemies() {
+        predicates.add(p -> p.getValue() < Standard.STANDARD_NEUTRAL);
+        return this;
+    }
+
+    /**
+     * Select only {@link IPerson} instances with a value exactly equal to the provided value
+     * @param value The friendliness value to select for
+     * @return      The mutated {@link Selector}
+     */
+    public Selector<P, T> exactValue(double value) {
+        predicates.add(p -> p.getValue() == value);
+        return this;
+    }
+
+    /**
+     * Select only {@link IPerson} instances whose association is equal to the provided association
+     * @param association   The association to select for
+     * @return              The mutated {@link Selector}
+     * @see IPerson#getAssociation()
+     */
+    public Selector<P, T> association(Association association) {
+        predicates.add(p -> p.getAssociation() == association);
+        return this;
+    }
+
+    /**
+     * Returns a set of {@link IPerson} instances from this {@link Selector}'s {@link Configuration} that match all selection predicates
+     * @return  The {@link Set} the selection provided
+     */
+    public Set<P> selectMatchingAll() {
+        return select(p -> predicates.stream().allMatch(predicate -> predicate.test(p)));
+    }
+
+    /**
+     * Returns a set of {@link IPerson} instances from this {@link Selector}'s {@link Configuration} that match none of the selection predicates
+     * @return  The {@link Set} the selection provided
+     */
+    public Set<P> selectMatchingNone() {
+        return select(p -> predicates.stream().noneMatch(predicate -> predicate.test(p)));
+    }
+
+    /**
+     * Returns a set of {@link IPerson} instances from this {@link Selector}'s {@link Configuration} that match any of the selection predicates
+     * @return  The {@link Set} the selection provided
+     */
+    public Set<P> selectMatchingAny() {
+        return select(p -> predicates.stream().anyMatch(predicate -> predicate.test(p)));
+    }
+
+    private Set<P> select(Predicate<P> predicate) {
+        return Collections.unmodifiableSet(this.configuration.getFriendList().stream().filter(predicate).collect(Collectors.toSet()));
+    }
+
+}

--- a/UniversalFriends-core/src/test/java/me/ironexception/universalfriends/association/AssociationTest.java
+++ b/UniversalFriends-core/src/test/java/me/ironexception/universalfriends/association/AssociationTest.java
@@ -11,44 +11,9 @@ class AssociationTest {
     @Test
     @DisplayName("Grab associations by value")
     void byValue() {
-        assertEquals(Association.ALLY, Association.byValue(Standard.STANDARD_ALLY), "ByValue works for allies");
-        assertEquals(Association.NEUTRAL, Association.byValue(Standard.STANDARD_NEUTRAL), "ByValue works for neutrals");
-        assertEquals(Association.ENEMY, Association.byValue(Standard.STANDARD_ENEMY), "ByValue works for enemies");
+        assertEquals(Association.ALLY, Association.byExactValue(Standard.STANDARD_ALLY), "ByValue works for allies");
+        assertEquals(Association.NEUTRAL, Association.byExactValue(Standard.STANDARD_NEUTRAL), "ByValue works for neutrals");
+        assertEquals(Association.ENEMY, Association.byExactValue(Standard.STANDARD_ENEMY), "ByValue works for enemies");
     }
 
-    @Test
-    @DisplayName("Closest to value")
-    void closestToValue() {
-        final double[] convergeToEnemy = new double[] {
-                Double.MIN_VALUE,
-                -2,
-                -1,
-                -0.5
-        };
-
-        final double[] convergeToNeutral = new double[] {
-                -0.4,
-                0,
-                0.4
-        };
-
-        final double[] convergeToAlly = new double[] {
-                0.5,
-                1,
-                2,
-                Double.MAX_VALUE
-        };
-
-        for (double v : convergeToEnemy) {
-            assertEquals(Association.ENEMY, Association.closestToValue(v), v + " is closest to ENEMY");
-        }
-
-        for (double v : convergeToNeutral) {
-            assertEquals(Association.NEUTRAL, Association.closestToValue(v), v + " is closest to NEUTRAL");
-        }
-
-        for (double v : convergeToAlly) {
-            assertEquals(Association.ALLY, Association.closestToValue(v), v + " is closest to ALLY");
-        }
-    }
 }

--- a/UniversalFriends-core/src/test/java/me/ironexception/universalfriends/configuration/OperationsTest.java
+++ b/UniversalFriends-core/src/test/java/me/ironexception/universalfriends/configuration/OperationsTest.java
@@ -38,12 +38,6 @@ class OperationsTest {
     }
 
     @Test
-    @DisplayName("Get by close to association")
-    void getByCloseToAssociation() {
-        assertEquals("bar", Operations.getByCloseToAssociation(configuration, Association.ALLY).stream().findAny().get().getName());
-    }
-
-    @Test
     @DisplayName("Get by association")
     void getByAssociation() {
         assertEquals("baz", Operations.getByAssociation(configuration, Association.ENEMY).stream().findAny().get().getName());

--- a/UniversalFriends-core/src/test/java/me/ironexception/universalfriends/select/SelectorTest.java
+++ b/UniversalFriends-core/src/test/java/me/ironexception/universalfriends/select/SelectorTest.java
@@ -1,0 +1,94 @@
+package me.ironexception.universalfriends.select;
+
+import me.ironexception.universalfriends.TestUtil;
+import me.ironexception.universalfriends.association.Association;
+import me.ironexception.universalfriends.configuration.Configuration;
+import me.ironexception.universalfriends.json.FriendFileLoader;
+import me.ironexception.universalfriends.json.FriendFileLoaderException;
+import me.ironexception.universalfriends.person.Person;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SelectorTest {
+
+    private static Configuration<Person> configuration;
+
+    @Test
+    @BeforeAll
+    public static void init() throws URISyntaxException, IOException, FriendFileLoaderException {
+        configuration = FriendFileLoader.defaultLoader()
+                .withPath(TestUtil.getPath("friends_selections.json"))
+                .load();
+    }
+
+    private static boolean setHasNames(Set<Person> set, String... names) {
+        return set.stream().map(Person::getName).collect(Collectors.toSet()).equals(new HashSet<>(Arrays.asList(names)));
+    }
+
+    @Test
+    @DisplayName("Friends")
+    void friends() {
+        assertTrue(setHasNames(
+                Selector.create(configuration).friends().selectMatchingAll(),
+                "John", "Mark"));
+    }
+
+    @Test
+    @DisplayName("Enemies")
+    void enemies() {
+        assertTrue(setHasNames(
+                Selector.create(configuration).enemies().selectMatchingAll(),
+                "Ben", "Jack"));
+    }
+
+    @Test
+    @DisplayName("Exact value")
+    void exactValue() {
+        assertTrue(setHasNames(
+                Selector.create(configuration).exactValue(-1).selectMatchingAll(),
+                "Ben"));
+    }
+
+    @Test
+    @DisplayName("Association")
+    void association() {
+        assertTrue(setHasNames(
+                Selector.create(configuration).association(Association.NEUTRAL).selectMatchingAll(),
+                "Alice"));
+    }
+
+    @Test
+    @DisplayName("Match all")
+    void selectMatchingAll() {
+        assertTrue(setHasNames(
+                Selector.create(configuration).enemies().friends().selectMatchingAll()
+        )); // No results, because no one is both a friend and an enemy.
+    }
+
+    @Test
+    @DisplayName("None")
+    void selectMatchingNone() {
+        assertTrue(setHasNames(
+                Selector.create(configuration).enemies().friends().selectMatchingNone(),
+                "Alice")); // Only alice isn't an enemy or a friend.
+    }
+
+    @Test
+    @DisplayName("Any")
+    void selectMatchingAny() {
+        assertTrue(setHasNames(
+                Selector.create(configuration).enemies().friends().selectMatchingAny(),
+                "John", "Ben", "Mark", "Jack")); // Only alice isn't an enemy or a friend.
+    }
+}

--- a/UniversalFriends-core/src/test/resources/friends_selections.json
+++ b/UniversalFriends-core/src/test/resources/friends_selections.json
@@ -1,0 +1,33 @@
+{
+  "bounds": {
+    "minimum": -2,
+    "maximum": 2
+  },
+  "list": [
+    {
+      "id": "8a2a3ef5-8d27-41b9-a69a-cbb05ac0ed1d",
+      "name": "Alice",
+      "value": 0
+    },
+    {
+      "id": "2ccc9554-2679-11ea-978f-2e728ce88125",
+      "name": "John",
+      "value": 2
+    },
+    {
+      "id": "8a2a3ef5-8d27-41b9-978f-2e728ce88125",
+      "name": "Ben",
+      "value": -1
+    },
+    {
+      "id": "f1d4ba3b-1809-4012-b5ec-840a541db399",
+      "name": "Mark",
+      "value": 1
+    },
+    {
+      "id": "a43a3d75-cd23-43a7-8fce-daf02b578bac",
+      "name": "Jack",
+      "value": -2
+    }
+  ]
+}

--- a/UniversalFriends-minecraft/src/main/java/me/ironexception/universalfriends/UniversalFriends.java
+++ b/UniversalFriends-minecraft/src/main/java/me/ironexception/universalfriends/UniversalFriends.java
@@ -104,7 +104,7 @@ public class UniversalFriends extends Configuration<GameProfilePerson> {
 
     /**
      * Creates a {@link Selector} for {@link UniversalFriends}'s {@link UniversalFriends#INSTANCE}
-     * @return
+     * @return The selector
      */
     public static Selector<GameProfilePerson, UniversalFriends> selector() {
         return Selector.create(UniversalFriends.INSTANCE);

--- a/UniversalFriends-minecraft/src/main/java/me/ironexception/universalfriends/UniversalFriends.java
+++ b/UniversalFriends-minecraft/src/main/java/me/ironexception/universalfriends/UniversalFriends.java
@@ -6,6 +6,7 @@ import me.ironexception.universalfriends.configuration.Configuration;
 import me.ironexception.universalfriends.json.Bounds;
 import me.ironexception.universalfriends.json.FriendFileLoader;
 import me.ironexception.universalfriends.json.FriendFileLoaderException;
+import me.ironexception.universalfriends.select.Selector;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -99,6 +100,14 @@ public class UniversalFriends extends Configuration<GameProfilePerson> {
      */
     public static void installRemoveCallback(Consumer<GameProfilePerson> consumer) {
         ((FriendsSet) UniversalFriends.INSTANCE.getFriendList()).removeCallbacks.add(consumer);
+    }
+
+    /**
+     * Creates a {@link Selector} for {@link UniversalFriends}'s {@link UniversalFriends#INSTANCE}
+     * @return
+     */
+    public static Selector<GameProfilePerson, UniversalFriends> selector() {
+        return Selector.create(UniversalFriends.INSTANCE);
     }
 
 }


### PR DESCRIPTION
Replaces #24 

Implements selectors to perform selections on `Configuration`s.
Usage:

Select only friends:
```java
Set<Person> friends = Selector.create(myConfiguration)
    .friends()
    .selectMatchingAll()
```
Select anything but friends:
```java
Set<Person> enemiesAndNeutrals = Selector.create(myConfiguration)
    .friends()
    .selectMatchingNone()
```
Select friends or enemies, but not neutrals:
```java
Set<Person> enemiesAndFriends = Selector.create(myConfiguration)
    .friends()
    .enemies()
    .selectMatchingAny()
```
etc.